### PR TITLE
Odstranění hard-coded hesla

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,10 +36,11 @@ Nainstalujte závislosti a vytvoře konfiguraci
 pip install -r requirements.txt
 cd svjis
 python manage.py migrate
-python manage.py svjis_setup
+python manage.py svjis_setup --password <heslo pro uživatele admin>
 ```
 
-Abyste mohli zkompilovat překlady, budete potřebovat nainstalovanou utilitu `gettext` - vyzkoušejte `gettext --version`. Pokud jí nemáte, tak následující krok klidně přeskočte a aplikace bude dostupná jen v angličtině.
+> [!NOTE]
+> Abyste mohli zkompilovat překlady, budete potřebovat nainstalovanou utilitu `gettext` - vyzkoušejte `gettext --version`. Pokud jí nemáte, tak následující krok klidně přeskočte a aplikace bude dostupná jen v angličtině.
 ```
 python manage.py compilemessages
 ```
@@ -50,7 +51,7 @@ python manage.py compilemessages
 python manage.py runserver
 ```
 
-Aplikace běží na adrese http://127.0.0.1:8000/ uživatel je `admin` heslo je `masterkey`. Heslo změňte v **Osobní nastavení - Změna hesla**.
+Aplikace běží na adrese http://127.0.0.1:8000/ uživatel je `admin` heslo je vámi dříve zadané heslo.
 
 Uvedený způsob spuštění je vhodný pro rychlé vyzkoušení aplikace na vašem počítači, nebo pro vývojáře. Pokud chcete SVJIS nasadit na server do produkce tak si prostudujte [Django dokumentaci](https://docs.djangoproject.com/en/5.0/howto/deployment/).
 

--- a/svjis/articles/management/commands/svjis_setup.py
+++ b/svjis/articles/management/commands/svjis_setup.py
@@ -128,7 +128,7 @@ def create_groups():
 def create_admin_user(password: str = None):
     print("Creating admin user...")
     u = User.objects.create_superuser(
-        username='admin', email='admin@test.cz', password=make_password(password), last_name='admin'
+        username='admin', email='admin@test.cz', password=password, last_name='admin'
     )
     g = Group.objects.get(name='Administrátor')
     u.groups.add(g)
@@ -199,7 +199,13 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         password = options["password"]
         if password is None and sys.stdin.isatty():
-            password = getpass.getpass("Enter password for admin user: ")
+            while True:
+                password = getpass.getpass("Enter password for admin user: ")
+                password2 = getpass.getpass("Enter password again: ")
+                if password == password2 and password != "":
+                    break
+                print("Passwords don't match.")
+
         with transaction.atomic():
             create_article_menu()
             create_advert_types()

--- a/svjis/articles/management/commands/svjis_setup.py
+++ b/svjis/articles/management/commands/svjis_setup.py
@@ -2,7 +2,6 @@ import getpass
 import sys
 
 from django.core.management.base import BaseCommand
-from django.contrib.auth.hashers import make_password
 from django.contrib.auth.models import User, Group, Permission
 from django.db import transaction
 

--- a/svjis/articles/management/commands/svjis_setup.py
+++ b/svjis/articles/management/commands/svjis_setup.py
@@ -1,3 +1,6 @@
+import getpass
+import sys
+
 from django.core.management.base import BaseCommand
 from django.contrib.auth.hashers import make_password
 from django.contrib.auth.models import User, Group, Permission
@@ -195,6 +198,8 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         password = options["password"]
+        if password is None and sys.stdin.isatty():
+            password = getpass.getpass("Enter password for admin user: ")
         with transaction.atomic():
             create_article_menu()
             create_advert_types()

--- a/svjis/articles/management/commands/svjis_setup.py
+++ b/svjis/articles/management/commands/svjis_setup.py
@@ -127,9 +127,7 @@ def create_groups():
 
 def create_admin_user(password: str = None):
     print("Creating admin user...")
-    u = User.objects.create_superuser(
-        username='admin', email='admin@test.cz', password=password, last_name='admin'
-    )
+    u = User.objects.create_superuser(username='admin', email='admin@test.cz', password=password, last_name='admin')
     g = Group.objects.get(name='Administrátor')
     u.groups.add(g)
     print("Done")


### PR DESCRIPTION
Toto odstraní hard-coded heslo z management příkazu `svjis_setup`. Heslo lze nyní předávat jako parametr `--password`. Pokud heslo není zadáno a příkaz je spuštěn z TTY, tak se na heslo zeptá interaktivně.

Neřešil jsem "zadejte heslo dvakrát" ani to, když uživatel zadá prázdné heslo a nebude se moci přihlásit. Od toho má k dispozci [changepassword](https://docs.djangoproject.com/en/5.0/ref/django-admin/#django-admin-changepassword) :smile: