### PR TITLE
Init factory-boy

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -42,7 +42,7 @@ jobs:
           python -m venv venv
           source venv/bin/activate
           python -m pip install --upgrade pip
-          pip install -r requirements.txt
+          pip install -r requirements-dev.txt
 
       - name: Setup Application
         run: |

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,3 +2,4 @@
 
 django-stubs==5.0.2
 pre-commit==3.7.1
+factory-boy==3.3.0

--- a/svjis/articles/tests/factories/__init__.py
+++ b/svjis/articles/tests/factories/__init__.py
@@ -1,0 +1,15 @@
+from .content_type import ContentTypeFactory
+from .permission import PermissionFactory
+from .group import GroupFactory
+from .user import UserFactory
+from .article_menu import ArticleMenuFactory
+from .article import ArticleFactory
+
+__all__ = [
+    "ContentTypeFactory",
+    "PermissionFactory",
+    "GroupFactory",
+    "UserFactory",
+    "ArticleMenuFactory",
+    "ArticleFactory",
+]

--- a/svjis/articles/tests/factories/article.py
+++ b/svjis/articles/tests/factories/article.py
@@ -1,0 +1,43 @@
+import factory
+
+from . import ArticleMenuFactory
+from ...models import Article
+from .user import UserFactory
+
+
+class ArticleFactory(factory.django.DjangoModelFactory):
+    header = factory.Faker('sentence', nb_words=6)
+    slug = factory.Faker('slug')
+    author = factory.SubFactory(UserFactory)
+    created_date = factory.Faker('date_time')
+    published = factory.Faker('boolean')
+    perex = factory.Faker('text')
+    body = factory.Faker('text')
+    menu = factory.SubFactory(ArticleMenuFactory)
+    allow_comments = factory.Faker('boolean')
+    visible_for_all = factory.Faker('boolean')
+
+    class Meta:
+        model = Article
+
+    @factory.post_generation
+    def watching_users(self, create, extracted, **kwargs):
+        if not create:
+            # Simple build, do nothing.
+            return
+
+        if extracted:
+            # A list of watching_users were passed in, use them
+            for watching_user in extracted:
+                self.watching_users.add(watching_user)
+
+    @factory.post_generation
+    def visible_for_group(self, create, extracted, **kwargs):
+        if not create:
+            # Simple build, do nothing.
+            return
+
+        if extracted:
+            # A list of visible_for_group were passed in, use them
+            for group in extracted:
+                self.visible_for_group.add(group)

--- a/svjis/articles/tests/factories/article_menu.py
+++ b/svjis/articles/tests/factories/article_menu.py
@@ -1,0 +1,12 @@
+import factory
+
+from ...models import ArticleMenu
+
+
+class ArticleMenuFactory(factory.django.DjangoModelFactory):
+    description = factory.Faker('sentence', nb_words=6)
+    hide = False
+    parent = factory.LazyAttribute(lambda x: ArticleMenuFactory(parent=None))
+
+    class Meta:
+        model = ArticleMenu

--- a/svjis/articles/tests/factories/content_type.py
+++ b/svjis/articles/tests/factories/content_type.py
@@ -1,0 +1,12 @@
+import factory
+
+from django.contrib.contenttypes.models import ContentType
+
+
+class ContentTypeFactory(factory.django.DjangoModelFactory):
+    app_label = factory.Faker('word')
+    model = factory.Faker('word')
+
+    class Meta:
+        model = ContentType
+        django_get_or_create = ("app_label", "model")

--- a/svjis/articles/tests/factories/group.py
+++ b/svjis/articles/tests/factories/group.py
@@ -1,0 +1,21 @@
+import factory
+
+from django.contrib.auth import models
+
+
+class GroupFactory(factory.django.DjangoModelFactory):
+    name = factory.Faker("word")
+
+    class Meta:
+        model = models.Group
+
+    @factory.post_generation
+    def permissions(self, create, extracted, **kwargs):
+        if not create:
+            # Simple build, do nothing.
+            return
+
+        if extracted:
+            # A list of permissions were passed in, use them
+            for permission in extracted:
+                self.permissions.add(permission)

--- a/svjis/articles/tests/factories/permission.py
+++ b/svjis/articles/tests/factories/permission.py
@@ -1,0 +1,15 @@
+import factory
+
+from django.contrib.auth import models
+
+from . import ContentTypeFactory
+
+
+class PermissionFactory(factory.django.DjangoModelFactory):
+    name = factory.Faker("word")
+    content_type = factory.SubFactory(ContentTypeFactory, app_label="articles")
+    codename = factory.Faker("word")
+
+    class Meta:
+        model = models.Permission
+        django_get_or_create = ("codename",)

--- a/svjis/articles/tests/factories/user.py
+++ b/svjis/articles/tests/factories/user.py
@@ -1,0 +1,26 @@
+import factory
+
+from django.contrib.auth import models
+
+
+class UserFactory(factory.django.DjangoModelFactory):
+    username = factory.Faker("user_name")
+    email = factory.Faker("email")
+    password = factory.django.Password("password")
+    first_name = factory.Faker("first_name")
+    last_name = factory.Faker("last_name")
+    is_active = True
+
+    class Meta:
+        model = models.User
+
+    @factory.post_generation
+    def groups(self, create, extracted, **kwargs):
+        if not create:
+            # Simple build, do nothing.
+            return
+
+        if extracted:
+            # A list of groups were passed in, use them
+            for group in extracted:
+                self.groups.add(group)

--- a/svjis/articles/tests/testdata/__init__.py
+++ b/svjis/articles/tests/testdata/__init__.py
@@ -1,0 +1,7 @@
+from .user_data import UserDataMixin
+from .article_data import ArticleDataMixin
+
+__all__ = (
+    "UserDataMixin",
+    "ArticleDataMixin",
+)

--- a/svjis/articles/tests/testdata/article_data.py
+++ b/svjis/articles/tests/testdata/article_data.py
@@ -1,0 +1,57 @@
+from ..factories import ArticleMenuFactory, ArticleFactory
+from .user_data import UserDataMixin
+
+
+class ArticleDataMixin(UserDataMixin):
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+
+        cls.menu_docs = ArticleMenuFactory(description="Documents")
+
+        cls.article_not_published = ArticleFactory(
+            header='Not Published',
+            menu=cls.menu_docs,
+            author=cls.u_jiri,
+            published=False,
+            visible_for_all=True,
+        )
+        cls.article_for_no_one = ArticleFactory(
+            header='For no one',
+            menu=cls.menu_docs,
+            author=cls.u_jiri,
+            published=True,
+            visible_for_all=False,
+        )
+        cls.article_for_all = ArticleFactory(
+            header='For All',
+            menu=cls.menu_docs,
+            author=cls.u_jiri,
+            published=True,
+            visible_for_all=True,
+        )
+        cls.article_for_owners = ArticleFactory(
+            header='For Owners',
+            menu=cls.menu_docs,
+            author=cls.u_jiri,
+            published=True,
+            visible_for_all=False,
+            visible_for_group=[cls.g_owner],
+        )
+        cls.article_for_owners_and_board = ArticleFactory(
+            header='For Owners and Board',
+            menu=cls.menu_docs,
+            author=cls.u_jiri,
+            published=True,
+            visible_for_all=False,
+            visible_for_group=[cls.g_owner, cls.g_board_member],
+        )
+        cls.article_for_board = ArticleFactory(
+            header='For Board',
+            menu=cls.menu_docs,
+            author=cls.u_jiri,
+            published=True,
+            visible_for_all=False,
+            visible_for_group=[cls.g_board_member],
+        )

--- a/svjis/articles/tests/testdata/user_data.py
+++ b/svjis/articles/tests/testdata/user_data.py
@@ -1,0 +1,92 @@
+from ..factories import GroupFactory, UserFactory, PermissionFactory
+
+
+class UserDataMixin:
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.g_owner = GroupFactory(
+            name="owner",
+            permissions=[
+                PermissionFactory(codename="svjis_add_article_comment"),
+                PermissionFactory(codename="svjis_view_personal_menu"),
+                PermissionFactory(codename="svjis_view_phonelist"),
+                PermissionFactory(codename="svjis_answer_survey"),
+            ],
+        )
+        cls.g_board_member = GroupFactory(
+            name="board_member",
+            permissions=[
+                PermissionFactory(codename="svjis_add_article_comment"),
+                PermissionFactory(codename="svjis_view_personal_menu"),
+                PermissionFactory(codename="svjis_view_phonelist"),
+            ],
+        )
+        cls.g_vendor = GroupFactory(
+            name="vendor",
+            permissions=[
+                PermissionFactory(codename="svjis_add_article_comment"),
+                PermissionFactory(codename="svjis_view_personal_menu"),
+            ],
+        )
+        cls.g_redactor = GroupFactory(
+            name="redactor",
+            permissions=[
+                PermissionFactory(codename="svjis_view_redaction_menu"),
+                PermissionFactory(codename="svjis_edit_article"),
+                PermissionFactory(codename="svjis_edit_article_menu"),
+                PermissionFactory(codename="svjis_edit_survey"),
+                PermissionFactory(codename="svjis_edit_article_news"),
+            ],
+        )
+        cls.g_admin = GroupFactory(
+            name="admin",
+            permissions=[
+                PermissionFactory(codename="svjis_view_redaction_menu"),
+                PermissionFactory(codename="svjis_edit_article"),
+                PermissionFactory(codename="svjis_add_article_comment"),
+                PermissionFactory(codename="svjis_edit_article_menu"),
+                PermissionFactory(codename="svjis_edit_article_news"),
+                PermissionFactory(codename="svjis_view_admin_menu"),
+                PermissionFactory(codename="svjis_edit_admin_users"),
+                PermissionFactory(codename="svjis_edit_admin_groups"),
+                PermissionFactory(codename="svjis_view_personal_menu"),
+                PermissionFactory(codename="svjis_edit_admin_preferences"),
+                PermissionFactory(codename="svjis_edit_admin_company"),
+                PermissionFactory(codename="svjis_edit_admin_building"),
+                PermissionFactory(codename="svjis_view_phonelist"),
+            ],
+        )
+
+        cls.u_jiri = UserFactory(
+            username="jiri",
+            email="jiri@test.cz",
+            password="jiri",
+            first_name="Jiří",
+            last_name="Brambůrek",
+            groups=[cls.g_owner, cls.g_board_member, cls.g_redactor],
+        )
+        cls.u_petr = UserFactory(
+            username="petr",
+            email="petr@test.cz",
+            password="petr",
+            first_name="Petr",
+            last_name="Nebus",
+            groups=[cls.g_owner],
+        )
+        cls.u_karel = UserFactory(
+            username="karel",
+            email="karel@test.cz",
+            password="karel",
+            first_name="Karel",
+            last_name="Lukáš",
+            groups=[cls.g_vendor],
+        )
+        cls.u_jarda = UserFactory(
+            username="jarda",
+            email="jarda@test.cz",
+            password="jarda",
+            first_name="Jaroslav",
+            last_name="Beran",
+            groups=[cls.g_owner, cls.g_board_member, cls.g_admin],
+        )


### PR DESCRIPTION
Cílem tohoto PR je udělat unit-testy trochu více robusnější. To sebou přináší další knihovnu [factory-boy](https://pypi.org/project/factory-boy/) která má ulehčit vytváření testovacích dat, (např. `Article` musí mít `perex`, který ale může vygenerovat `ArticleFactory` a tak se může z konstrukce testovacích dat přesunout do factory). Složka `tests/testdata` pak spojuje volání factory, za předpokladu, že se bude používat opakovaně.

V poslední řadě zavádí naming convention, kde každý testovaný soubor (aktuálně pouze `views.py`) má své testy v souboru `test_views.py`