### PR TITLE
Init dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+# Config for Dependabot updates. See Documentation here:
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  # Update GitHub actions in workflows
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    # Every weekday
+    schedule:
+      interval: 'weekly'
+
+  # Enable version updates for Python/Pip - Production
+  - package-ecosystem: 'pip'
+    # Look for a `requirements.txt` in the `root` directory
+    # also 'setup.cfg', 'runtime.txt' and 'requirements/*.txt'
+    directory: '/'
+    # Every weekday
+    schedule:
+      interval: 'weekly'


### PR DESCRIPTION
Tohle přidává konfiguraci pro [dependabot](https://docs.github.com/en/code-security/getting-started/dependabot-quickstart-guide), který poté automaticky vytváří PR s aktualizací knihoven, jako třeba [tady](https://github.com/SukiCZ/svjis2/pulls)

Je pravda, že jsem musel ještě v nastavení tuto možnost zapnout, v sekci `Dependabot/Dependabot version updates`. URL bude něco jako
https://github.com/svjis/svjis2/settings/security_analysis#security_analysis_bucket
